### PR TITLE
fixed quantiles.py to write complete list of values

### DIFF
--- a/gcp/extract/quantiles.py
+++ b/gcp/extract/quantiles.py
@@ -127,5 +127,5 @@ for filestuff in data:
                     writer.writerow(list(rowstuff) + list(distribution.inverse(evalqvals)))
             elif output_format == 'valuescsv':
                 for ii in range(len(allvalues)):
-                    writer.writerow(list(rowstuff) + allmontevales[ii] + [allvalues[ii], allweights[ii]])
+                    writer.writerow(list(rowstuff) + allmontevales[ii] + [list(allvalues[ii]), allweights[ii]])
 


### PR DESCRIPTION
If output-format is valuescsv, previously the code would write an abbreviated list [1 2 ..., 10] in the "value" column of the output file. With this change, the complete list of values is written tot he output file.