### PR TITLE
Adds support for mean under parallel deltamethod

### DIFF
--- a/gcp/extract/lib/weights_vcv.py
+++ b/gcp/extract/lib/weights_vcv.py
@@ -44,11 +44,20 @@ class WeightedGMCDF(object):
         # find root for each probability
         roots = []
         for p in pp:
+            if p == 2:
+                roots.append(np.average(self.means, weights=self.weights))
+                continue
+            
             # Set up mixed distribution CDF with root and find it
             func = lambda x: sum(self.weights * norm.cdf(x, self.means, self.sds)) - p
             roots.append(brentq(func, left, right))
 
         return roots
+
+    @staticmethod
+    def encode_evalqvals(evalqvals):
+        encoder = {'mean': 2}
+        return map(lambda p: p if isinstance(p, float) else encoder[p], evalqvals)
 
 if __name__ == '__main__':
     ## Example between R and python

--- a/gcp/extract/lib/weights_vcv.py
+++ b/gcp/extract/lib/weights_vcv.py
@@ -39,15 +39,16 @@ class WeightedGMCDF(object):
             pp = np.array([pp])
 
         # determine extreme left and right bounds for root-finding
+        pp = np.array(pp) # needs to be np array
         left = np.min(norm.ppf(np.min(pp), self.means, self.sds))
-        right = np.max(norm.ppf(np.max(pp), self.means, self.sds))
+        right = np.max(norm.ppf(np.max(pp[pp < 1]), self.means, self.sds))
         # find root for each probability
         roots = []
         for p in pp:
             if p == 2:
                 roots.append(np.average(self.means, weights=self.weights))
                 continue
-            
+
             # Set up mixed distribution CDF with root and find it
             func = lambda x: sum(self.weights * norm.cdf(x, self.means, self.sds)) - p
             roots.append(brentq(func, left, right))

--- a/gcp/extract/quantiles.py
+++ b/gcp/extract/quantiles.py
@@ -54,7 +54,7 @@ for filestuff in data:
         if output_format == 'edfcsv':
             writer.writerow(rownames + map(lambda q: q if isinstance(q, str) else 'q' + str(int(q * 100)), evalqvals))
             if configs.is_parallel_deltamethod(config):
-                encoded_evalqvals = weights.WeightedGMCDF.encode_evalqvals(evalqvals)
+                encoded_evalqvals = weights_vcv.WeightedGMCDF.encode_evalqvals(evalqvals)
             else:
                 encoded_evalqvals = weights.WeightedECDF.encode_evalqvals(evalqvals)
         elif output_format == 'valuescsv':

--- a/gcp/extract/quantiles.py
+++ b/gcp/extract/quantiles.py
@@ -53,7 +53,10 @@ for filestuff in data:
 
         if output_format == 'edfcsv':
             writer.writerow(rownames + map(lambda q: q if isinstance(q, str) else 'q' + str(int(q * 100)), evalqvals))
-            encoded_evalqvals = weights.WeightedECDF.encode_evalqvals(evalqvals)
+            if configs.is_parallel_deltamethod(config):
+                encoded_evalqvals = weights.WeightedGMCDF.encode_evalqvals(evalqvals)
+            else:
+                encoded_evalqvals = weights.WeightedECDF.encode_evalqvals(evalqvals)
         elif output_format == 'valuescsv':
             writer.writerow(rownames + ['batch', 'gcm', 'iam', 'value', 'weight'])
 


### PR DESCRIPTION
Adds support for named metrics to the parallel deltamethod setup. Uses the same approach as the normal quantile system (encoding the named values as numeric options). Currently only `mean` is supported.