### PR TITLE
Cheap workaround for deltamethod quantiles.py memory explosion

### DIFF
--- a/gcp/extract/lib/bundles.py
+++ b/gcp/extract/lib/bundles.py
@@ -31,11 +31,12 @@ def read_region(target_regions, *args, **kwargs):
 
     Quick and dirty hax to reduce the size of data read in from netCDF files.
     Keeps a memory leak in the module from blowing up the script. Not
-    the best way to handle this. This should not be in production code.
+    the best way to handle this.
 
     Parameters
     ----------
     target_regions : sequence of strs
+        Regions to extract. If empty list or 'all', extracts all regions.
     *args :
         Passed on to read().
     **kwargs :
@@ -53,6 +54,10 @@ def read_region(target_regions, *args, **kwargs):
 
     years, regions, data = read(*args, **kwargs)
     regions_msk = np.isin(regions, target_regions)
+
+    if target_regions == ['all'] or target_regions == []:
+        regions_msk[:] = True
+
     return years, regions[regions_msk], data[..., regions_msk]
 
 

--- a/gcp/extract/lib/configs.py
+++ b/gcp/extract/lib/configs.py
@@ -191,6 +191,9 @@ def get_regions(config, allregions=None):
     if allregions is None:
         allregions = []
 
+    if 'region' not in config.keys() and 'regions' not in config.keys():
+        return []
+
     if 'region' in config:
         return [config['region']]
 

--- a/gcp/extract/lib/configs.py
+++ b/gcp/extract/lib/configs.py
@@ -187,7 +187,10 @@ def interpret_filenames(argv, config):
 def is_allregions(config):
     return not ('region' in config or 'regions' in config) and not 'region' in config.get('file-organize', [])
 
-def get_regions(config, allregions):
+def get_regions(config, allregions=None):
+    if allregions is None:
+        allregions = []
+
     if 'region' in config:
         return [config['region']]
 


### PR DESCRIPTION
Close #14.

This is a very rough and dirty workaround for a quantiles.py memory leak.

We briefly testing output from this branch against pre-workaround output. This is described in #14.