### PR TITLE
Added config option for specifying a single SSP scenario in quantiles.py.

### DIFF
--- a/gcp/extract/config-docs.md
+++ b/gcp/extract/config-docs.md
@@ -64,11 +64,15 @@ Perform operations for only one RCP or realization?  Set to `null` for all RCPs.
 
 ## `only-iam` (options: null, low, high)
 
-Perform operations for only one IAM (high or low)?  Set to `null` for all RCPs.
+Perform operations for only one IAM (high or low)?  Set to `null` for all IAMs.
 
 ## `only-models` (options: all (default), or list
 
 Only include certain climate models in the results.  e.g., `[hadgem2-ao, hadgem2-es]`.
+
+## `only-ssp` (options: null, SSP1, SSP2, SSP3, SSP4, or SSP5)
+ 
+Perform operations for only one SSP scenario?  Set to `null` for all SSPs.
 
 ## `checks` (options: null or list of files)
 

--- a/gcp/extract/lib/configs.py
+++ b/gcp/extract/lib/configs.py
@@ -55,6 +55,7 @@ def iterate_valid_targets(root, config, impacts=None, verbose=True):
     do_montecarlo = config.get('do-montecarlo', False)
     do_rcp_only = config.get('only-rcp', None)
     do_iam_only = config.get('only-iam', None)
+    do_ssp_only = config.get('only-ssp', None)
     do_targetsubdirs = config.get('targetsubdirs', None)
     do_batchdir = config.get('batchdir', 'median')
     checks = config.get('checks', None)
@@ -95,6 +96,9 @@ def iterate_valid_targets(root, config, impacts=None, verbose=True):
             continue
         if do_iam_only and iam != do_iam_only:
             print targetdir, "not", do_iam_only
+            continue
+        if do_ssp_only and ssp != do_ssp_only:
+            print targetdir, "not", do_ssp_only
             continue
         if allmodels is not None and model not in allmodels:
             print targetdir, "not in", allmodels

--- a/gcp/extract/quantiles.py
+++ b/gcp/extract/quantiles.py
@@ -10,6 +10,8 @@ Supported configuration options:
 - output-dir
 - do-montecarlo
 - only-rcp
+- only-iam
+- only-ssp
 - only-models (default: `all`)
 - deltamethod (default: `no`) -- otherwise, results root for deltamethod
 - file-organize (default: rcp, ssp)


### PR DESCRIPTION
Closes #17. I tested this on mortality sector output and it works fine. I also corrected a couple minor consistency issues in the documentation.