### PR TITLE
Support region config

### DIFF
--- a/gcp/extract/config-docs.md
+++ b/gcp/extract/config-docs.md
@@ -52,6 +52,10 @@ Only extract results for the given years, if provided.
 
 # Region handling
 
+## `region` (options: null or string)
+
+Only extract results for a single region, if provided
+
 ## `regions` (options: null or list of regions)
 
 Only extract results for the given regions, if provided

--- a/gcp/extract/lib/configs.py
+++ b/gcp/extract/lib/configs.py
@@ -205,6 +205,9 @@ def get_regions(config, allregions):
     -------
     Iterable
     """
+    if 'region' in config:
+        return [config['region']]
+    
     regions = config.get('regions', allregions)
 
     if 'global' in regions:

--- a/gcp/extract/lib/configs.py
+++ b/gcp/extract/lib/configs.py
@@ -195,6 +195,11 @@ def is_allregions(config):
 def get_regions(config, allregions):
     """Grab and parse regions to extract from file
 
+    This handles the specification of the desired regions. Both a
+    `region` (a single region as a string) and `regions` (a list of
+    region names) config argument are supported, as well as some key
+    names within the regions list: 'global', 'countries', and 'funds'.
+
     Parameters
     ----------
     config : dict
@@ -204,6 +209,7 @@ def get_regions(config, allregions):
     Returns
     -------
     Iterable
+
     """
     if 'region' in config:
         return [config['region']]


### PR DESCRIPTION
The handling for the `region` config argument was dropped, and this adds it back in. This resolves #30 .